### PR TITLE
Add grocat subcommand

### DIFF
--- a/src/bentopy/__init__.py
+++ b/src/bentopy/__init__.py
@@ -127,7 +127,8 @@ def main():
         "-t",
         "--title",
         type=str,
-        help="Set the final title. By default, the first file's title is used.",
+        default="bentopy grocat",
+        help="Set the final title. (default: %(default)s)",
     )
     grocat_parser.add_argument(
         "-b",

--- a/src/bentopy/__init__.py
+++ b/src/bentopy/__init__.py
@@ -1,9 +1,12 @@
 import argparse
-import pathlib
+from pathlib import Path
+from sys import stdout
 
 from render._render import py_render_placements as render_placements
-from .pack import pack
+
+from .grocat import grocat
 from .mask import mask
+from .pack import pack
 
 __all__ = ["render_placements"]
 
@@ -41,7 +44,7 @@ def main():
     )
     render_parser.add_argument(
         "input",
-        type=pathlib.Path,
+        type=Path,
         help="""
         Path to the placement list.
 
@@ -50,12 +53,12 @@ def main():
     )
     render_parser.add_argument(
         "output",
-        type=pathlib.Path,
+        type=Path,
         help="Output gro file path.",
     )
     render_parser.add_argument(
         "--root",
-        type=pathlib.Path,
+        type=Path,
         help="""
         Root path for the structure paths.
         
@@ -80,7 +83,7 @@ def main():
         "-t",
         "--topology",
         dest="topol",
-        type=pathlib.Path,
+        type=Path,
         help="Write a topology (.top) file.",
     )
     mode_or_topol.add_argument(
@@ -95,6 +98,38 @@ def main():
         help=mask.DESCRIPTION,
     )
     mask.setup_parser(mask_parser)
+
+    grocat_parser = subparsers.add_parser(
+        "grocat",
+        help="Concatenate gro files.",
+    )
+    grocat_parser.add_argument(
+        "files",
+        type=argparse.FileType("r"),
+        nargs="+",
+        help="Files to concatenate (gro).",
+    )
+    grocat_parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType("w"),
+        required=True,
+        help="Output path.",
+    )
+    grocat_parser.add_argument(
+        "-t",
+        "--title",
+        type=str,
+        help="Set the final title. By default, the first file's title is used.",
+    )
+    grocat_parser.add_argument(
+        "-b",
+        "--box",
+        type=grocat.parse_boxvec,
+        help="""Set the final box vectors. 
+        Expects a valid gro box line, which is a space-separated list of either 3 or 9 floats. 
+        By default, the box vector of the first file is chosen.""",
+    )
 
     args = parser.parse_args()
 
@@ -115,3 +150,5 @@ def main():
         )
     elif args.subcommand == "mask":
         mask.main(args)
+    elif args.subcommand == "grocat":
+        grocat.main(args)

--- a/src/bentopy/__init__.py
+++ b/src/bentopy/__init__.py
@@ -105,9 +105,16 @@ def main():
     )
     grocat_parser.add_argument(
         "files",
-        type=argparse.FileType("r"),
+        type=grocat.InputFile,
         nargs="+",
-        help="Files to concatenate (gro).",
+        help="""Files to concatenate (gro; <path>[:<resname>]). 
+
+        Optionally, a residue name can be set for all atoms in a file by 
+        appending a colon followed by the residue name. 
+        Note that this name can be at most 5 characters long. 
+
+        Replacing the residue names can be very useful in distinguishing between 
+        parts of very large systems within a concatenated file.""",
     )
     grocat_parser.add_argument(
         "-o",

--- a/src/bentopy/grocat/grocat.py
+++ b/src/bentopy/grocat/grocat.py
@@ -1,0 +1,90 @@
+from sys import exit, stderr
+
+# This should be sufficient space to write the final natoms into.
+NATOMS_PLACEHOLDER = " " * 32
+
+
+def eprint(*args, **kwargs):
+    """
+    Print to standard error.
+    """
+    print(*args, **kwargs, file=stderr)
+
+
+def guarantee_newline(line: str) -> str:
+    """
+    If the provided line does not have a trailing newline, yet, add it.
+    Otherwise leave it alone.
+
+    Note that this is an idempotent operation (i.e., ∀x f(x) = f(f(x))).
+    """
+    if line.endswith("\n"):
+        return line
+    else:
+        return line + "\n"
+
+
+def parse_boxvec(s: str) -> tuple[float]:
+    """
+    Parse a gro box vector line.
+    """
+    boxvec = [float(v) for v in s.split()]
+    nv = len(boxvec)
+    if nv == 3 or nv == 9:
+        return boxvec
+    raise ValueError(
+        f"Could not parse '{s}'. The box vector must have either 3 or 9 values, found {nv}."
+    )
+
+
+def main(args):
+    output = args.output
+    if not output.seekable():
+        eprint("ERROR: Output into non-seekable files is currently not supported.")
+        exit(1)
+
+    title = args.title
+    # Write the title if we already know what it is.
+    if title is not None:
+        output.write(guarantee_newline(title))
+
+    boxvecs = []
+    natoms_total = 0
+    natoms_location = None  # The location in output where the natoms are written.
+    # We know that there will be at least one file provided through args.
+    for file in args.files:
+        eprint(f"Reading from {file.name}...")
+
+        # Set the title if it has not been set, yet.
+        if title is None:
+            title = next(file)
+            output.write(title)
+        else:
+            next(file)  # Skip this title since we already set it.
+
+        # Put in a natoms placeholder if this is the first file that is written.
+        if natoms_location is None:
+            natoms_location = output.tell()
+            output.write(NATOMS_PLACEHOLDER + "\n")
+
+        # Read the number of atoms that are in this file.
+        natoms = int(next(file).strip())
+        # Write that number of lines into the output file.
+        for _ in range(natoms):
+            output.write(next(file))
+        # Now that we have written the lines, we'll add them to our total.
+        natoms_total += natoms
+
+        # Parse the box vector and add it to our collection.
+        boxvec = parse_boxvec(next(file))
+        boxvecs.append(boxvec)
+
+    # TODO: Take into account args.box.
+    # Write out the final box vector.
+    final_boxvec = boxvecs[0]
+    output.write(" ".join([str(v) for v in final_boxvec]) + "\n")
+
+    # Finally, we go and seek back to the start, where we left our natoms placeholder.
+    # Let's replace that with the correct total number of atom records we wrote to output.
+    output.seek(natoms_location)
+    output.write(str(natoms_total))

--- a/src/bentopy/grocat/grocat.py
+++ b/src/bentopy/grocat/grocat.py
@@ -62,10 +62,9 @@ def main(args):
         eprint("ERROR: Output into non-seekable files is currently not supported.")
         exit(1)
 
-    title = args.title
-    # Write the title if we already know what it is.
-    if title is not None:
-        output.write(guarantee_newline(title))
+    # Write the title.
+    if args.title is not None:
+        output.write(guarantee_newline(args.title))
 
     boxvecs = []
     natoms_total = 0
@@ -86,12 +85,7 @@ def main(args):
             info = f"Replacing resnames with '{resname}'."
         eprint(f"Reading from {file.name}...", info)
 
-        # Set the title if it has not been set, yet.
-        if title is None:
-            title = next(file)
-            output.write(title)
-        else:
-            next(file)  # Skip this title since we already set it.
+        next(file)  # Skip the title.
 
         # Put in a natoms placeholder if this is the first file that is written.
         if natoms_location is None:


### PR DESCRIPTION
The current implementation is somewhat limited. We only allow writing to files that are `seekable` (so stdout, for instance, is rejected as an output file).

It is reasonably fast, I think. Catting two 592 MB gro files takes around three seconds within the actual `grocat` command on my setup. I'm going to try to make it work with the files opened in byte mode in an upcoming commit here. 

- ~~Try reading and writing the files in byte mode.~~
    - This may improve performance by reducing some of the utf8 reading overhead, especially when it comes to reading in the input atom entries and immediately writing them to the output file.
    - We'll have to think somewhat carefully about the robustness implications for this. How easy is it to break this? Will people use emoji in their gro file names?? (Makes me curious, can we do that with Gromacs hahaha.)
    - **Nevermind**: this comes with a performance _regression_, not an improvement. I don't know why, exactly, and it may have to do with the poor quality of my experimental local attempt. But it seems that it is not worth more time for now. Might as well write it in a fast language if speed is really that important.

However, I think the performance of _overall_ use is extremely poor at the moment. The reason for this appears to be the overhead of loading the `bentopy` modules in `src/bentopy/__init__.py`. Good target for a future issue and pull request. For now I'll keep my eyes on getting this to work.

@jan-stevens, what do you think about the command and its interface? Is it helpful to you, and does it feature everything that you were looking for? (Probably forgot about something ;)