### PR TITLE
Add a constraints mechanism and configuration options

### DIFF
--- a/src/bentopy/pack/config.py
+++ b/src/bentopy/pack/config.py
@@ -16,7 +16,12 @@ class Configuration:
     ):
         config = json.loads(json_src)
         space = config["space"]
-        self.space = Space(space["size"], space["resolution"], space["compartments"])
+        self.space = Space(
+            space["size"],
+            space["resolution"],
+            space["compartments"],
+            space.get("constraint"),
+        )
         segments = config["segments"]
         self.segments = [
             Segment(

--- a/src/bentopy/pack/config.py
+++ b/src/bentopy/pack/config.py
@@ -30,6 +30,7 @@ class Configuration:
                 s["path"],
                 self.space.resolution,
                 s["compartments"],
+                s.get("rotation_axes"),
             )
             for s in segments
         ]

--- a/src/bentopy/pack/config.py
+++ b/src/bentopy/pack/config.py
@@ -31,6 +31,7 @@ class Configuration:
                 self.space.resolution,
                 s["compartments"],
                 s.get("rotation_axes"),
+                s.get("center"),
             )
             for s in segments
         ]

--- a/src/bentopy/pack/pack.py
+++ b/src/bentopy/pack/pack.py
@@ -41,12 +41,10 @@ def place(
     Place a number of segments into the background.
     """
 
-    segment_voxels = segment.voxels()
-
     start = time.time()
     # First, we convolve the background to reveal the points where we can
     # safely place a segment without overlapping them.
-    valid = space.collisions(segment_voxels, segment.center)
+    valid = space.collisions(segment)
     convolution_duration = time.time() - start
     log(f"        (convolution took {convolution_duration:.3f} s)")
 
@@ -74,8 +72,8 @@ def place(
 
         # Make sure that this placement does not overlap with another
         # previously selected location.
-        location = placement_location(valid, selection, segment_voxels)
-        prospect = np.where(segment_voxels) + location[:, None]
+        location = placement_location(valid, selection, segment.voxels())
+        prospect = np.where(segment.voxels()) + location[:, None]
         # Check for collisions at the prospective site.
         free = not np.any(
             space.squeezed_session_background[

--- a/src/bentopy/pack/pack.py
+++ b/src/bentopy/pack/pack.py
@@ -77,7 +77,9 @@ def place(
         prospect = np.where(segment_voxels) + location[:, None]
         # Check for collisions at the prospective site.
         free = not np.any(
-            space.squeezed_session_background[prospect[0, :], prospect[1, :], prospect[2, :]]
+            space.squeezed_session_background[
+                prospect[0, :], prospect[1, :], prospect[2, :]
+            ]
         )
 
         if free:
@@ -201,7 +203,7 @@ def pack(
                 f"    placed a total of {segment_hits}/{max_num} hits with a packing density of {density:.4f}"
             )
 
-        segment.rotation = R.random(random_state=RNG).as_matrix()
+        segment.set_rotation(R.random(random_state=RNG).as_matrix())
     end_volume = np.sum(space.global_background)
     density = (end_volume - start_volume) / max_volume
     print(

--- a/src/bentopy/pack/segment.py
+++ b/src/bentopy/pack/segment.py
@@ -59,8 +59,8 @@ class Segment:
         """
         return voxelize(self.rotation @ self.points().T, self.resolution, tighten=True)
 
-    def center_translation(self):
-        return np.array([0.0 if c is None else c for c in self.center])
+    def center_translation(self, dtype=float):
+        return np.array([0.0 if c is None else c for c in self.center], dtype=dtype)
 
     def set_rotation(self, rotation):
         """

--- a/src/bentopy/pack/segment.py
+++ b/src/bentopy/pack/segment.py
@@ -59,8 +59,10 @@ class Segment:
         """
         return voxelize(self.rotation @ self.points().T, self.resolution, tighten=True)
 
-    def center_translation(self, dtype=float):
-        return np.array([0.0 if c is None else c for c in self.center], dtype=dtype)
+    def center_translation(self, resolution=1.0, dtype=float):
+        return np.array(
+            [0.0 if c is None else c / resolution for c in self.center], dtype=dtype
+        )
 
     def set_rotation(self, rotation):
         """

--- a/src/bentopy/pack/space.py
+++ b/src/bentopy/pack/space.py
@@ -176,8 +176,7 @@ class Space:
         constraint_mask = np.ones(valid.shape[1], dtype=bool)
 
         # Apply an offset to the spots that are considered valid based on the possible center adjustment for a segment.
-        # relevant = np.array([1.0 if v is None else 0.0 for v in center])
-        center_offset = segment.center_translation(dtype=int)
+        center_offset = segment.center_translation(resolution=self.resolution, dtype=int)
         for compartment in self.compartments:
             if compartment.id not in segment.compartment_ids:
                 continue

--- a/src/bentopy/pack/space.py
+++ b/src/bentopy/pack/space.py
@@ -163,6 +163,7 @@ class Space:
         query = np.flip(segment_voxels)
         collisions = fftconvolve(self.squeezed_session_background, query, mode="valid")
 
+        # Take care of the smaller space that is produced by the convolution.
         valid_offset = np.array(query.shape) // 2
         # The valid placement points will have a value of 0. Since the floating
         # point operations leave some small errors laying around, we use a quite

--- a/src/bentopy/pack/space.py
+++ b/src/bentopy/pack/space.py
@@ -177,7 +177,7 @@ class Space:
 
         # Apply an offset to the spots that are considered valid based on the possible center adjustment for a segment.
         # relevant = np.array([1.0 if v is None else 0.0 for v in center])
-        center_offset = segment.center_translation() # FIXME dtype -> int
+        center_offset = segment.center_translation(dtype=int)
         for compartment in self.compartments:
             if compartment.id not in segment.compartment_ids:
                 continue


### PR DESCRIPTION
In this PR, I aim to add the following features:

- [x] Set axis constraints for a compartment, e.g., `axis:z=10.0`. Structures will be placed according to that constraint, by only returning valid voxel locations that _also_ match that axis constraint predicate.
- [x] Set rotation axis constraints per segment, e.g., `xyz` (the default), or `z` for membrane proteins that can only be rotated over their _z_-axis.
- [x] Set all or some of the center coordinates for a segment, e.g. `1.2, 3.4, 5.6`, `auto, auto, auto` (the default), or `auto, auto, 5.1` for some membrane protein that can be automatically centered over the _xy_ plane, but has a fixed center over the _z_ axis such that it can be placed with its transmembrane band over a specific _z_ range.