### PR TITLE
Implement an implied default compartment when compartment definitions are omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,30 @@ at 50 nm.
 
 </details>
 
+<details>
+<summary>Implied default compartment.</summary>
+
+If you omit the `"compartments"` field from the `"space"` section, and don't
+set the `"compartments"` field in any of the segments in the `"segments"`
+section, a single default compartment is implied.
+This compartment is set up like this.
+
+```json
+		{
+			"id": "main",
+			"shape": "cuboid"
+		}
+```
+
+Each segment, when the compartment is implied, is assigned to that `"main"`
+compartment.
+
+Note that when the `"compartments"` field on any segment is not set, its
+compartment id will be set to `"main"`, even when a compartment is defined in
+the `"space"` section.
+
+</details>
+
 #### Output
 
 In **output**, we set a **title** and **dir**ectory to write the placement list


### PR DESCRIPTION
These two configurations now produce the same behavior.

```diff
 {
        "space": {
                "size": [100, 100, 100],
-               "compartments": [
-                       {
-                               "id": "main",
-                               "shape": "spherical"
-                       }
-               ],
                "resolution": 0.5
        },
        "output": {
                "title": "3lyz",
                "dir": "outputs"
        },
        "segments": [
                {
                        "name": "3lyz",
                        "number": 100000,
-                       "compartments": ["main"],
                        "path": "structures/3lyz.pdb"
                }
        ]
 }
```

In case a `"compartments"` field is set for any of the segments, an error is thrown describing that the implied `"compartments"` definition in the `"space"` section is valid only if no segment has a `"compartments"` field.